### PR TITLE
feat: プロフィールページにTwitterカードのメタタグを追加

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -46,6 +46,8 @@ PROFILE_IMAGE_URL = "https://avatars.githubusercontent.com/u/57385580?v=4"
 PROFILE_BIO_LINES = (
     "メモを残します。",
 )
+PROFILE_OG_DESCRIPTION = "メモ書きをする場所"
+TWITTER_USERNAME = "@shima10_x1p"
 PROFILE_SOCIAL_LINKS = (
     ("GitHub", "https://github.com/shima10-x1p", "github"),
     ("Twitter", "https://x.com/shima10_x1p", "twitter"),

--- a/themes/shima-island-coral/templates/profile.html
+++ b/themes/shima-island-coral/templates/profile.html
@@ -2,6 +2,14 @@
 
 {% block title %}{{ page.title }} | {{ SITENAME }}{% endblock %}
 
+{% block extra_head %}
+<meta name="twitter:card" content="summary" />
+{% if TWITTER_USERNAME %}<meta name="twitter:site" content="{{ TWITTER_USERNAME }}" />{% endif %}
+<meta name="twitter:title" content="{{ PROFILE_NAME or AUTHOR }}" />
+{% if PROFILE_OG_DESCRIPTION %}<meta name="twitter:description" content="{{ PROFILE_OG_DESCRIPTION }}" />{% endif %}
+{% if PROFILE_IMAGE_URL %}<meta name="twitter:image" content="{{ PROFILE_IMAGE_URL }}" />{% endif %}
+{% endblock %}
+
 {% block content %}
 <div class="profile-page">
 


### PR DESCRIPTION
- pelicanconf.py に PROFILE_OG_DESCRIPTION・TWITTER_USERNAME を追加
- profile.html の extra_head ブロックに twitter:card, site, title, description, image を設定